### PR TITLE
[fix] Fix division-by-zero error

### DIFF
--- a/lib/fortuneteller/simulation.rb
+++ b/lib/fortuneteller/simulation.rb
@@ -182,8 +182,10 @@ module FortuneTeller
 
         monthly_guaranteed.map do |month|
           total = 0
-          month.each do |k,v|
-            total += (v.to_f*year_cashflow[:posttax][k]/year_cashflow[:pretax][k]).round
+          month.each do |k, v|
+            next if v.zero?
+
+            total += (v.to_f * year_cashflow[:posttax][k]/year_cashflow[:pretax][k]).round
           end
           total
         end


### PR DESCRIPTION
Pretax income can be zero, but only if the month's income of the same type was zero -- in which case we can skip the calculation anyway.