### PR TITLE
[scoring] Expose inflation-adjusted income in results

### DIFF
--- a/lib/fortuneteller/result_serializers/monte_carlo.rb
+++ b/lib/fortuneteller/result_serializers/monte_carlo.rb
@@ -14,6 +14,7 @@ module FortuneTeller
 
       def set_cashflow(i, cashflow)
         @result[i][:income] = cashflow[:posttax]
+        @result[i][:income_inf_adj] = @sim.deflate(amount: cashflow[:posttax][:total], year_index: i).round
       end
 
       def output

--- a/lib/fortuneteller/simulation.rb
+++ b/lib/fortuneteller/simulation.rb
@@ -5,6 +5,8 @@ module FortuneTeller
     end
 
     attr_accessor :account_keys
+    attr_reader :start_year, :growth_rates
+
     def initialize(
         result_serializer:, 
         initial_state:, 
@@ -67,6 +69,11 @@ module FortuneTeller
 
     def inflate(amount:, date:)
       @inflating_int_cache.calculate(amount, date)
+    end
+
+    def deflate(amount:, year_index:)
+      factor = @growth_rates.cumulative(:inflation, @start_year, @start_year + year_index)
+      amount / factor
     end
 
     def inflate_year(amount:, year:)


### PR DESCRIPTION
Useful for aggregation. Basically the same change as #5 but remade with the new serializers.