### PR TITLE
[fix] Date calculation when the day-of-month is invalid

### DIFF
--- a/lib/fortuneteller/guaranteed_income/component.rb
+++ b/lib/fortuneteller/guaranteed_income/component.rb
@@ -8,7 +8,8 @@ module FortuneTeller
 
         simulator.years.each do |year|
           data = (1..12).map do |month|
-            day_plan = reader.on(Date.new(year, month, day))
+            date = Date.new(year, month, day) rescue Date.new(year, month, -1)
+            day_plan = reader.on(date)
             (day_plan.nil? ? nil : day_plan.generator_data(year, month))
           end
           generators[year] = FortuneTeller::GuaranteedIncome::Generator.new(data: data, holder: holder, year: year)


### PR DESCRIPTION
```
irb(main):002:0> year = 2018
=> 2018
irb(main):003:0> month = 2
=> 2
irb(main):004:0> day = 31
=> 31
irb(main):005:0> Date.new(year, month, day)
ArgumentError: invalid date
irb(main):006:0> Date.new(year, month, day) rescue Date.new(year, month, -1)
=> #<Date: 2018-02-28>
```